### PR TITLE
Fix readline.setup

### DIFF
--- a/readline/trunk/readline.setup
+++ b/readline/trunk/readline.setup
@@ -36,7 +36,7 @@
    "-C -D_GNU_SOURCE=1"
    " -C -std=gnu99"
    (let ((cflags (get-environment-variable "CFLAGS")))
-     (if (not (string=? "" cflags))
+     (if cflags
 	 (string-append " -C "
 			(string-join
 			 (string-split cflags " ")


### PR DESCRIPTION
The egg doesn't compile for me otherwise as `get-environment-variable` returns `#f` if it's unset which cannot be used in string procedures.
