### PR TITLE
Remove dead code causing warning on readline 7.0

### DIFF
--- a/readline/trunk/interface.c
+++ b/readline/trunk/interface.c
@@ -304,7 +304,6 @@ void gnu_readline_init()
      rl_bind_keyseq("[D", highlight_paren);
 #endif
      rl_completion_entry_function = &gnu_readline_tab_complete;
-     rl_variable_bind("rl_catch_signals", 0);
      rl_clear_signals();
      rl_set_signals();
      rl_completer_quote_characters = "\"";


### PR DESCRIPTION
Readline 7.0 landed in Arch.  After rebuilding the readline egg, I got a warning when using it:

    readline: rl_catch_signals: unknown variable name

This is apparently the fault of the initialization code which uses `rl_variable_bind` on "rl_catch_signals".  Judging from [the documentation](http://tiswww.case.edu/php/chet/readline/readline.html) this function is for setting variables intended for user customization, none of which use snake case or a "rl_" prefix.  Neither does the relevant section have a "catch-signals" customizable, so I suspect that code never worked in the first place and can be safely removed.